### PR TITLE
Refactor for more testing rigour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ _testmain.go
 
 # vendored libraries
 vendor
+
+# coverage
+coverage.out

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+# vendored libraries
+vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ go:
     - 1.6
     - 1.5
 
+env:
+    - GO15VENDOREXPERIMENT=1
+
 notifications:
     email: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
     - tip
     - 1.6
+    - 1.5
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
 notifications:
     email: false
 
-before_script:
+before_install:
     - curl -o /tmp/glide.tar.gz --location https://github.com/Masterminds/glide/releases/download/0.10.2/glide-0.10.2-linux-amd64.tar.gz
     - tar -xzvf /tmp/glide.tar.gz
     - export PATH=$PATH:$PWD/linux-amd64/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ before_install:
 
 install:
     - glide install
+
+script: make coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,16 @@
 language: go
-go: tip
+
+go:
+    - tip
+    - 1.6
+
 notifications:
     email: false
+
+before_script:
+    - curl -o /tmp/glide.tar.gz --location https://github.com/Masterminds/glide/releases/download/0.10.2/glide-0.10.2-linux-amd64.tar.gz
+    - tar -xzvf /tmp/glide.tar.gz
+    - export PATH=$PATH:$PWD/linux-amd64/
+
+install:
+    - glide install

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,6 @@ test:
 clean:
 	rm -f $(COVERAGE)
 
-.PHONY: cover
-cover: test
+.PHONY: coverage
+coverage: test
 	$(GOCOVER) -func=$(COVERAGE)

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# Makefile for thingful/httpmock
+#
+# Targets:
+# 	test: runs tests
+#
+GOCMD=go
+GOTEST=$(GOCMD) test -v
+GOCOVER=$(GOCMD) tool cover
+COVERAGE=coverage.out
+
+.PHONY: test
+test:
+	$(GOTEST) -coverprofile=$(COVERAGE)
+
+.PHONY: clean
+clean:
+	rm -f $(COVERAGE)
+
+.PHONY: cover
+cover: test
+	$(GOCOVER) -func=$(COVERAGE)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ func TestFetchArticles(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles.json",
-		httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`))
+	httpmock.RegisterStubRequest(&httpmock.StubRequest{
+    Method: "GET",
+    URL: "https://api.mybiz.com/articles.json",
+		Responder: httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`),
+  })
 
 	// do stuff that makes a request to articles.json
 }
@@ -24,19 +27,23 @@ func TestFetchArticles(t *testing.T) {
 	articles := make([]map[string]interface{}, 0)
 
 	// mock to list out the articles
-	httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles.json",
-		func(req *http.Request) (*http.Response, error) {
+	httpmock.RegisterStubRequest(&httpmock.StubRequest{
+    Method: "GET",
+    URL: "https://api.mybiz.com/articles.json",
+		Responder: func(req *http.Request) (*http.Response, error) {
 			resp, err := httpmock.NewJsonResponse(200, articles)
 			if err != nil {
 				return httpmock.NewStringResponse(500, ""), nil
 			}
 			return resp, nil
 		},
-	)
+	})
 
 	// mock to add a new article
-	httpmock.RegisterResponder("POST", "https://api.mybiz.com/articles.json",
-		func(req *http.Request) (*http.Response, error) {
+	httpmock.RegisterStubRequest(&httpmock.StubRequest{
+    Method: "POST",
+    URL: "https://api.mybiz.com/articles.json",
+		Responder: func(req *http.Request) (*http.Response, error) {
 			article := make(map[string]interface{})
 			if err := json.NewDecoder(req.Body).Decode(&article); err != nil {
 				return httpmock.NewStringResponse(400, ""), nil
@@ -50,7 +57,7 @@ func TestFetchArticles(t *testing.T) {
 			}
 			return resp, nil
 		},
-	)
+	})
 
 	// do stuff that adds and checks articles
 }

--- a/README.md
+++ b/README.md
@@ -7,13 +7,18 @@ func TestFetchArticles(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterStubRequest(&httpmock.StubRequest{
-    Method: "GET",
-    URL: "https://api.mybiz.com/articles.json",
-		Responder: httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`),
-  })
+	httpmock.RegisterStubRequest(httpmock.NewStubRequest(
+    "GET",
+    "https://api.mybiz.com/articles.json",
+		httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`),
+  ))
 
 	// do stuff that makes a request to articles.json
+
+  // verify all registered stubs were called
+  if err := httpmock.AllStubsWereCalled(); err != nil {
+    t.Errorf("Not all stubs were called: %s", err)
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,31 @@ func TestFetchArticles(t *testing.T) {
 }
 ```
 
+### Headers Example:
+```go
+func TestFetchArticles(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterStubRequest(
+    httpmock.NewStubRequest(
+      "GET",
+      "https://api.mybiz.com/articles.json",
+		  httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`),
+    ).WithHeaders(&http.Header{
+      "Accept": []string{"application/json"},
+    })
+  )
+
+	// do stuff that makes a request to articles.json
+
+  // verify all registered stubs were called
+  if err := httpmock.AllStubsWereCalled(); err != nil {
+    t.Errorf("Not all stubs were called: %s", err)
+  }
+}
+```
+
 ### Advanced Example:
 ```go
 func TestFetchArticles(t *testing.T) {
@@ -32,17 +57,19 @@ func TestFetchArticles(t *testing.T) {
 	articles := make([]map[string]interface{}, 0)
 
 	// mock to list out the articles
-	httpmock.RegisterStubRequest(&httpmock.StubRequest{
-    Method: "GET",
-    URL: "https://api.mybiz.com/articles.json",
-		Responder: func(req *http.Request) (*http.Response, error) {
-			resp, err := httpmock.NewJsonResponse(200, articles)
-			if err != nil {
-				return httpmock.NewStringResponse(500, ""), nil
-			}
-			return resp, nil
-		},
-	})
+	httpmock.RegisterStubRequest(
+    httpmock.NewStubRequest(
+      "GET",
+      "https://api.mybiz.com/articles.json",
+		  func(req *http.Request) (*http.Response, error) {
+			  resp, err := httpmock.NewJsonResponse(200, articles)
+			  if err != nil {
+				  return httpmock.NewStringResponse(500, ""), nil
+			  }
+			  return resp, nil
+		  }
+    ))
+	)
 
 	// mock to add a new article
 	httpmock.RegisterStubRequest(&httpmock.StubRequest{

--- a/README.md
+++ b/README.md
@@ -7,16 +7,18 @@ func TestFetchArticles(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	httpmock.RegisterStubRequest(httpmock.NewStubRequest(
-    "GET",
-    "https://api.mybiz.com/articles.json",
-		httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`),
-  ))
+	httpmock.RegisterStubRequest(
+    httpmock.NewStubRequest(
+      "GET",
+      "https://api.mybiz.com/articles.json",
+		  httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`),
+    ),
+  )
 
 	// do stuff that makes a request to articles.json
 
   // verify all registered stubs were called
-  if err := httpmock.AllStubsWereCalled(); err != nil {
+  if err := httpmock.AllStubsCalled(); err != nil {
     t.Errorf("Not all stubs were called: %s", err)
   }
 }
@@ -41,7 +43,7 @@ func TestFetchArticles(t *testing.T) {
 	// do stuff that makes a request to articles.json
 
   // verify all registered stubs were called
-  if err := httpmock.AllStubsWereCalled(); err != nil {
+  if err := httpmock.AllStubsCalled(); err != nil {
     t.Errorf("Not all stubs were called: %s", err)
   }
 }

--- a/doc.go
+++ b/doc.go
@@ -1,15 +1,24 @@
 /*
-HTTPmock provides tools for mocking HTTP responses.
+Package httpmock provides tools for mocking HTTP responses.
 
 Simple Example:
 	func TestFetchArticles(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 
-		httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles.json",
-			httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`))
+		httpmock.RegisterResponder(
+			httpmock.NewStubRequest(
+				"GET",
+				"https://api.mybiz.com/articles.json",
+				httpmock.NewStringResponder(200, `[{"id": 1, "name": "My Great Article"}]`,
+			)))
 
 		// do stuff that makes a request to articles.json
+
+		// verify that all stubs were called
+		if err := httpmock.AllStubsCalled(); err != nil {
+				t.Errorf("Not all stubs were called: %s", err)
+		}
 	}
 
 Advanced Example:
@@ -21,35 +30,56 @@ Advanced Example:
 		articles := make([]map[string]interface{}, 0)
 
 		// mock to list out the articles
-		httpmock.RegisterResponder("GET", "https://api.mybiz.com/articles.json",
-			func(req *http.Request) (*http.Response, error) {
-				resp, err := httpmock.NewJsonResponse(200, articles)
-				if err != nil {
-					return httpmock.NewStringResponse(500, ""), nil
-				}
-				return resp
-			},
-		)
+		httpmock.RegisterResponder(
+			httpmock.NewStubRequest(
+				"GET",
+				"https://api.mybiz.com/articles.json",
+				func(req *http.Request) (*http.Response, error) {
+					resp, err := httpmock.NewJsonResponse(200, articles)
+					if err != nil {
+						return httpmock.NewStringResponse(500, ""), nil
+					}
+					return resp
+				},
+			).WithHeader(
+				&http.Header{
+					"Api-Key": []string{"1234abcd"},
+				},
+			))
 
 		// mock to add a new article
-		httpmock.RegisterResponder("POST", "https://api.mybiz.com/articles.json",
-			func(req *http.Request) (*http.Response, error) {
-				article := make(map[string]interface{})
-				if err := json.NewDecoder(req.Body).Decode(&article); err != nil {
-					return httpmock.NewStringResponse(400, ""), nil
-				}
+		httpmock.RegisterResponder(
+			httpmock.NewStubRequest(
+				"POST",
+				"https://api.mybiz.com/articles.json",
+				func(req *http.Request) (*http.Response, error) {
+					article := make(map[string]interface{})
+					if err := json.NewDecoder(req.Body).Decode(&article); err != nil {
+						return httpmock.NewStringResponse(400, ""), nil
+					}
 
-				articles = append(articles, article)
+					articles = append(articles, article)
 
-				resp, err := httpmock.NewJsonResponse(200, article)
-				if err != nil {
-					return httpmock.NewStringResponse(500, ""), nil
-				}
-				return resp, nil
-			},
-		)
+					resp, err := httpmock.NewJsonResponse(200, article)
+					if err != nil {
+						return httpmock.NewStringResponse(500, ""), nil
+					}
+					return resp, nil
+				},
+			).WithHeader(
+				&http.Header{
+					"Api-Key": []string{"1234abcd"},
+				},
+			).WithBody(
+				bytes.NewBufferString(`{"title":"article"}`),
+			))
 
 		// do stuff that adds and checks articles
+
+		// verify that all stubs were called
+		if err := httpmock.AllStubsCalled(); err != nil {
+				t.Errorf("Not all stubs were called: %s", err)
+		}
 	}
 
 */

--- a/doc.go
+++ b/doc.go
@@ -6,7 +6,7 @@ Simple Example:
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 
-		httpmock.RegisterResponder(
+		httpmock.RegisterStubRequest(
 			httpmock.NewStubRequest(
 				"GET",
 				"https://api.mybiz.com/articles.json",

--- a/doc_test.go
+++ b/doc_test.go
@@ -1,0 +1,39 @@
+package httpmock
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+func ExampleRegisterStubRequest() {
+	Activate()
+	defer DeactivateAndReset()
+
+	RegisterStubRequest(
+		NewStubRequest(
+			"GET",
+			"http://example.com/",
+			NewStringResponder(200, "ok"),
+		),
+	)
+
+	resp, err := http.Get("http://example.com/")
+	if err != nil {
+		// handle error
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		// handle error
+	}
+
+	fmt.Println(string(body))
+
+	if err = AllStubsCalled(); err != nil {
+		// handle error
+	}
+
+	// Output: ok
+}

--- a/env.go
+++ b/env.go
@@ -6,6 +6,7 @@ import (
 
 var envVarName = "GONOMOCKS"
 
+// Disabled returns true if the GONOMOCKS environment variable is not empty
 func Disabled() bool {
 	return os.Getenv(envVarName) != ""
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,14 @@
-hash: 5f25851f51584dcc9178ad1155632e9daa8a711898489327999c9886cc16ef28
-updated: 2016-05-11T22:24:45.901023892+01:00
+hash: ce28c1e4b3c6ba46e287a9a61c9f63ad1493cc72f2cc8afb1f227ea383bfd8ee
+updated: 2016-07-01T01:02:00.734965001+01:00
 imports:
 - name: github.com/goware/urlx
   version: 86bdc24560383254e8b977da31a823eddf904409
-- name: github.com/opennota/urlesc
-  version: 5fa9ff0392746aeae1c4b37fcc42c65afa7a9587
 - name: github.com/PuerkitoBio/purell
-  version: d69616f51cdfcd7514d6a380847a152dfc2a749d
+  version: 1d5d1cfad45d42ec5f81fa8ef23de09cebc6dcc3
+- name: github.com/PuerkitoBio/urlesc
+  version: 5fa9ff0392746aeae1c4b37fcc42c65afa7a9587
 - name: golang.org/x/net
-  version: 96dbb961a39ddccf16860cdd355bfa639c497f23
+  version: b400c2eff1badec7022a8c8f5bea058b6315eed7
   subpackages:
   - idna
 devImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,14 @@
+hash: 5f25851f51584dcc9178ad1155632e9daa8a711898489327999c9886cc16ef28
+updated: 2016-05-11T22:24:45.901023892+01:00
+imports:
+- name: github.com/goware/urlx
+  version: 86bdc24560383254e8b977da31a823eddf904409
+- name: github.com/opennota/urlesc
+  version: 5fa9ff0392746aeae1c4b37fcc42c65afa7a9587
+- name: github.com/PuerkitoBio/purell
+  version: d69616f51cdfcd7514d6a380847a152dfc2a749d
+- name: golang.org/x/net
+  version: 96dbb961a39ddccf16860cdd355bfa639c497f23
+  subpackages:
+  - idna
+devImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: ce28c1e4b3c6ba46e287a9a61c9f63ad1493cc72f2cc8afb1f227ea383bfd8ee
-updated: 2016-07-01T01:02:00.734965001+01:00
+hash: 5c99a192912f6eadfbe5355a11011fee7d6dc128f63ff7d972bcdc49a50864bb
+updated: 2016-07-02T01:54:23.6598234+01:00
 imports:
 - name: github.com/goware/urlx
   version: 86bdc24560383254e8b977da31a823eddf904409

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,3 +1,3 @@
-package: github.com/smulube/httpmock
+package: github.com/thingful/httpmock
 import:
 - package: github.com/goware/urlx

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,3 @@
+package: github.com/smulube/httpmock
+import:
+- package: github.com/goware/urlx

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,3 +1,4 @@
 package: github.com/thingful/httpmock
 import:
 - package: github.com/goware/urlx
+  version: 86bdc24560383254e8b977da31a823eddf904409

--- a/response.go
+++ b/response.go
@@ -49,9 +49,9 @@ func NewBytesResponder(status int, body []byte) Responder {
 	return ResponderFromResponse(NewBytesResponse(status, body))
 }
 
-// NewJsonResponse creates an *http.Response with a body that is a json encoded representation of
+// NewJSONResponse creates an *http.Response with a body that is a json encoded representation of
 // the given interface{}.  Also accepts an http status code.
-func NewJsonResponse(status int, body interface{}) (*http.Response, error) {
+func NewJSONResponse(status int, body interface{}) (*http.Response, error) {
 	encoded, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
@@ -61,19 +61,19 @@ func NewJsonResponse(status int, body interface{}) (*http.Response, error) {
 	return response, nil
 }
 
-// NewJsonResponder creates a Responder from a given body (as an interface{} that is encoded to
+// NewJSONResponder creates a Responder from a given body (as an interface{} that is encoded to
 // json) and status code.
-func NewJsonResponder(status int, body interface{}) (Responder, error) {
-	resp, err := NewJsonResponse(status, body)
+func NewJSONResponder(status int, body interface{}) (Responder, error) {
+	resp, err := NewJSONResponse(status, body)
 	if err != nil {
 		return nil, err
 	}
 	return ResponderFromResponse(resp), nil
 }
 
-// NewXmlResponse creates an *http.Response with a body that is an xml encoded representation
-// of the given interface{}.  Also accepts an http status code.
-func NewXmlResponse(status int, body interface{}) (*http.Response, error) {
+// NewXMLResponse creates an *http.Response with a body that is an xml encoded
+// representation of the given interface{}.  Also accepts an http status code.
+func NewXMLResponse(status int, body interface{}) (*http.Response, error) {
 	encoded, err := xml.Marshal(body)
 	if err != nil {
 		return nil, err
@@ -83,18 +83,18 @@ func NewXmlResponse(status int, body interface{}) (*http.Response, error) {
 	return response, nil
 }
 
-// NewXmlResponder creates a Responder from a given body (as an interface{} that is encoded to xml)
-// and status code.
-func NewXmlResponder(status int, body interface{}) (Responder, error) {
-	resp, err := NewXmlResponse(status, body)
+// NewXMLResponder creates a Responder from a given body (as an interface{}
+// that is encoded to xml) and status code.
+func NewXMLResponder(status int, body interface{}) (Responder, error) {
+	resp, err := NewXMLResponse(status, body)
 	if err != nil {
 		return nil, err
 	}
 	return ResponderFromResponse(resp), nil
 }
 
-// NewRespBodyFromString creates an io.ReadCloser from a string that is suitable for use as an
-// http response body.
+// NewRespBodyFromString creates an io.ReadCloser from a string that is
+// suitable for use as an http response body.
 func NewRespBodyFromString(body string) io.ReadCloser {
 	return &dummyReadCloser{strings.NewReader(body)}
 }

--- a/response_test.go
+++ b/response_test.go
@@ -46,7 +46,7 @@ func TestNewBytesResponse(t *testing.T) {
 	}
 }
 
-func TestNewJsonResponse(t *testing.T) {
+func TestNewJSONResponse(t *testing.T) {
 	type schema struct {
 		Hello string `json:"hello"`
 	}
@@ -54,7 +54,7 @@ func TestNewJsonResponse(t *testing.T) {
 	body := &schema{"world"}
 	status := 200
 
-	response, err := NewJsonResponse(status, body)
+	response, err := NewJSONResponse(status, body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +77,7 @@ func TestNewJsonResponse(t *testing.T) {
 	}
 }
 
-func TestNewXmlResponse(t *testing.T) {
+func TestNewXMLResponse(t *testing.T) {
 	type schema struct {
 		Hello string `xml:"hello"`
 	}
@@ -85,7 +85,7 @@ func TestNewXmlResponse(t *testing.T) {
 	body := &schema{"world"}
 	status := 200
 
-	response, err := NewXmlResponse(status, body)
+	response, err := NewXMLResponse(status, body)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/stubbed_request.go
+++ b/stubbed_request.go
@@ -42,5 +42,5 @@ type StubRequest struct {
 
 // Matches is a test function that returns true if an incoming request is matched by this fetcher.
 func (r *StubRequest) Matches(req *http.Request) bool {
-
+	return false
 }

--- a/stubbed_request.go
+++ b/stubbed_request.go
@@ -92,8 +92,7 @@ func (r *StubRequest) Matches(req *http.Request) error {
 		// make sure they are present in the corresponding header on the request
 		for header, stubValues := range map[string][]string(*r.Header) {
 			// get the values for this header on the request
-			reqValues := req.Header[header]
-
+			reqValues := req.Header[http.CanonicalHeaderKey(header)]
 			for _, v := range stubValues {
 				if !contains(reqValues, v) {
 					return ErrIncorrectHeaders

--- a/stubbed_request.go
+++ b/stubbed_request.go
@@ -7,14 +7,14 @@ import (
 	"github.com/goware/urlx"
 )
 
-// StubbedRequest is used to capture data about a new stubbed request. It wraps
+// StubRequest is used to capture data about a new stubbed request. It wraps
 // up the Method and URL along with optional http.Header struct, and also holds
 // the Responder.
-type StubbedRequest struct {
+type StubRequest struct {
 	Method    string
 	URL       string
 	Header    *http.Header
-	Responder *Responder
+	Responder Responder
 }
 
 // normalizedKey is a helper function that returns a normalized key for a

--- a/stubbed_request.go
+++ b/stubbed_request.go
@@ -2,33 +2,45 @@ package httpmock
 
 import (
 	"net/http"
-	"strings"
-
-	"github.com/goware/urlx"
 )
 
-// StubRequest is used to capture data about a new stubbed request. It wraps
-// up the Method and URL along with optional http.Header struct, and also holds
-// the Responder.
+// NewStubRequest is a constructor function that returns a StubRequest for the
+// given method and url. We also supply a responder which actually generates
+// the response should the stubbed request match the request.
+func NewStubRequest(method, url string, responder Responder) *StubRequest {
+	return &StubRequest{
+		Method:    method,
+		URL:       url,
+		Responder: responder,
+	}
+}
+
+// NewStubRequestWithHeaders is a constructor function that returns a
+// StubRequest for the given method and url provided the request contains the
+// supplied headers. We also supply a responder which actually generates the
+// response should the stubbed request match the request.
+func NewStubRequestWithHeaders(method, url string, header *http.Header, responder Responder) *StubRequest {
+	return &StubRequest{
+		Method:    method,
+		URL:       url,
+		Header:    header,
+		Responder: responder,
+	}
+}
+
+// StubRequest is used to capture data about a new stubbed request. It wraps up
+// the Method and URL along with optional http.Header struct, holds the
+// Responder used to generate a response, and also has a flag indicating
+// whether or not this stubbed request has actually been called.
 type StubRequest struct {
 	Method    string
 	URL       string
 	Header    *http.Header
 	Responder Responder
+	Called    bool
 }
 
-// normalizedKey is a helper function that returns a normalized key for a
-// method/url pair.
-func normalizedKey(method, url string) (string, error) {
-	u, err := urlx.Parse(url)
-	if err != nil {
-		return "", err
-	}
+// Matches is a test function that returns true if an incoming request is matched by this fetcher.
+func (r *StubRequest) Matches(req *http.Request) bool {
 
-	normalized, err := urlx.Normalize(u)
-	if err != nil {
-		return "", err
-	}
-
-	return strings.ToUpper(method) + " " + normalized, nil
 }

--- a/stubbed_request.go
+++ b/stubbed_request.go
@@ -1,0 +1,34 @@
+package httpmock
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/goware/urlx"
+)
+
+// StubbedRequest is used to capture data about a new stubbed request. It wraps
+// up the Method and URL along with optional http.Header struct, and also holds
+// the Responder.
+type StubbedRequest struct {
+	Method    string
+	URL       string
+	Header    *http.Header
+	Responder *Responder
+}
+
+// normalizedKey is a helper function that returns a normalized key for a
+// method/url pair.
+func normalizedKey(method, url string) (string, error) {
+	u, err := urlx.Parse(url)
+	if err != nil {
+		return "", err
+	}
+
+	normalized, err := urlx.Normalize(u)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.ToUpper(method) + " " + normalized, nil
+}

--- a/stubbed_request_test.go
+++ b/stubbed_request_test.go
@@ -1,0 +1,1 @@
+package httpmock

--- a/stubbed_request_test.go
+++ b/stubbed_request_test.go
@@ -1,48 +1,48 @@
 package httpmock
 
 import (
-	"bytes"
-	"io"
+	//"bytes"
+	//"io"
 	"net/http"
 	"testing"
 )
 
 func TestMatches(t *testing.T) {
 	testcases := []struct {
-		method     string
-		url        string
-		requestURL string
-		match      bool
+		method      string
+		url         string
+		requestURL  string
+		expectedErr bool
 	}{
 		{
 			"get",
 			"http://example.com",
 			"http://example.com",
-			true,
+			false,
 		},
 		{
 			"get",
 			"ExAmPlE.com?foo=val&bar=val#t=boo",
 			"http://example.com?bar=val&foo=val#t=boo",
-			true,
+			false,
 		},
 		{
 			"Get",
 			"http://example.com:80/?bar=val&foo=val#t=boo",
 			"http://example.com/?foo=val&bar=val#t=boo",
-			true,
+			false,
 		},
 		{
 			"get",
 			"example.com?foo=val&bar=val&n=another#t=boo",
 			"http://example.com?bar=val&foo=val#t=boo",
-			false,
+			true,
 		},
 		{
 			"GET",
 			"example.com/?foo=val&bar=val#t=bo",
 			"http://example.com/?foo=val&bar=val#t=boo",
-			false,
+			true,
 		},
 	}
 
@@ -58,121 +58,128 @@ func TestMatches(t *testing.T) {
 			t.Fatalf("Unexpected error, got %#v", err)
 		}
 
-		if stub.Matches(req) != testcase.match {
-			t.Errorf("Unexpected result expected '%#v', got '%#v' for %s", testcase.match, stub.Matches(req), testcase.url)
+		err = stub.Matches(req)
+		if testcase.expectedErr {
+			if err == nil {
+				t.Errorf("Didn't get error response when expected one: %s", testcase.url)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Unexpected error, got %#v", err)
+			}
 		}
 	}
 }
 
-func TestMatchesWithHeaders(t *testing.T) {
-	testcases := []struct {
-		method         string
-		stubUrl        string
-		stubHeaders    *http.Header
-		requestURL     string
-		requestHeaders http.Header
-		match          bool
-	}{
-		{
-			"get",
-			"http://example.com",
-			&http.Header{
-				"X-ApiKey": []string{"api-key"},
-			},
-			"http://example.com",
-			http.Header{
-				"X-ApiKey": []string{"api-key"},
-			},
-			true,
-		},
-		{
-			"get",
-			"http://example.com",
-			&http.Header{
-				"X-ApiKey": []string{"api-key"},
-			},
-			"http://example.com",
-			http.Header{
-				"X-ApiKey": []string{"another-api-key"},
-			},
-			false,
-		},
-		{
-			"get",
-			"http://example.com",
-			&http.Header{
-				"X-ApiKey": []string{"api-key"},
-				"Accept":   []string{"application/json"},
-			},
-			"http://example.com",
-			http.Header{
-				"X-ApiKey": []string{"api-key"},
-			},
-			false,
-		},
-	}
-
-	for _, testcase := range testcases {
-		stub := NewStubRequest(
-			testcase.method,
-			testcase.stubUrl,
-			NewStringResponder(200, "ok"),
-		).WithHeaders(testcase.stubHeaders)
-
-		req, err := http.NewRequest("GET", testcase.requestURL, nil)
-		if err != nil {
-			t.Fatalf("Unexpected error, got %#v", err)
-		}
-
-		req.Header = testcase.requestHeaders
-
-		if stub.Matches(req) != testcase.match {
-			t.Errorf("Unexpected result expected '%#v', got '%#v' for %s", testcase.match, stub.Matches(req), testcase.stubUrl)
-		}
-	}
-}
-
-func TestRequestWithBody(t *testing.T) {
-	testcases := []struct {
-		method      string
-		stubUrl     string
-		body        io.Reader
-		requestURL  string
-		requestBody io.Reader
-		match       bool
-	}{
-		{
-			"POST",
-			"http://example.com",
-			bytes.NewBufferString("foo=val"),
-			"http://example.com",
-			bytes.NewBufferString("foo=val"),
-			true,
-		},
-		{
-			"POST",
-			"http://example.com",
-			bytes.NewBufferString("foo=val"),
-			"http://example.com",
-			bytes.NewBufferString("bar=val"),
-			false,
-		},
-	}
-
-	for _, testcase := range testcases {
-		stub := NewStubRequest(
-			testcase.method,
-			testcase.stubUrl,
-			NewStringResponder(200, "ok"),
-		).WithBody(testcase.body)
-
-		req, err := http.NewRequest(testcase.method, testcase.requestURL, testcase.requestBody)
-		if err != nil {
-			t.Fatalf("Unexpected error, got %#v", err)
-		}
-
-		if stub.Matches(req) != testcase.match {
-			t.Errorf("Unexpected result expected '%#v', got '%#v' for %s", testcase.match, stub.Matches(req), testcase.stubUrl)
-		}
-	}
-}
+//func TestMatchesWithHeader(t *testing.T) {
+//	testcases := []struct {
+//		method         string
+//		stubURL        string
+//		stubHeaders    *http.Header
+//		requestURL     string
+//		requestHeaders http.Header
+//		match          bool
+//	}{
+//		{
+//			"get",
+//			"http://example.com",
+//			&http.Header{
+//				"X-ApiKey": []string{"api-key"},
+//			},
+//			"http://example.com",
+//			http.Header{
+//				"X-ApiKey": []string{"api-key"},
+//			},
+//			true,
+//		},
+//		{
+//			"get",
+//			"http://example.com",
+//			&http.Header{
+//				"X-ApiKey": []string{"api-key"},
+//			},
+//			"http://example.com",
+//			http.Header{
+//				"X-ApiKey": []string{"another-api-key"},
+//			},
+//			false,
+//		},
+//		{
+//			"get",
+//			"http://example.com",
+//			&http.Header{
+//				"X-ApiKey": []string{"api-key"},
+//				"Accept":   []string{"application/json"},
+//			},
+//			"http://example.com",
+//			http.Header{
+//				"X-ApiKey": []string{"api-key"},
+//			},
+//			false,
+//		},
+//	}
+//
+//	for _, testcase := range testcases {
+//		stub := NewStubRequest(
+//			testcase.method,
+//			testcase.stubURL,
+//			NewStringResponder(200, "ok"),
+//		).WithHeader(testcase.stubHeaders)
+//
+//		req, err := http.NewRequest("GET", testcase.requestURL, nil)
+//		if err != nil {
+//			t.Fatalf("Unexpected error, got %#v", err)
+//		}
+//
+//		req.Header = testcase.requestHeaders
+//
+//		if stub.Matches(req) != testcase.match {
+//			t.Errorf("Unexpected result expected '%#v', got '%#v' for %s", testcase.match, stub.Matches(req), testcase.stubURL)
+//		}
+//	}
+//}
+//
+//func TestRequestWithBody(t *testing.T) {
+//	testcases := []struct {
+//		method      string
+//		stubURL     string
+//		body        io.Reader
+//		requestURL  string
+//		requestBody io.Reader
+//		match       bool
+//	}{
+//		{
+//			"POST",
+//			"http://example.com",
+//			bytes.NewBufferString("foo=val"),
+//			"http://example.com",
+//			bytes.NewBufferString("foo=val"),
+//			true,
+//		},
+//		{
+//			"POST",
+//			"http://example.com",
+//			bytes.NewBufferString("foo=val"),
+//			"http://example.com",
+//			bytes.NewBufferString("bar=val"),
+//			false,
+//		},
+//	}
+//
+//	for _, testcase := range testcases {
+//		stub := NewStubRequest(
+//			testcase.method,
+//			testcase.stubURL,
+//			NewStringResponder(200, "ok"),
+//		).WithBody(testcase.body)
+//
+//		req, err := http.NewRequest(testcase.method, testcase.requestURL, testcase.requestBody)
+//		if err != nil {
+//			t.Fatalf("Unexpected error, got %#v", err)
+//		}
+//
+//		if stub.Matches(req) != testcase.match {
+//			t.Errorf("Unexpected result expected '%#v', got '%#v' for %s", testcase.match, stub.Matches(req), testcase.stubURL)
+//		}
+//	}
+//}

--- a/stubbed_request_test.go
+++ b/stubbed_request_test.go
@@ -65,3 +65,76 @@ func TestMatches(t *testing.T) {
 		}
 	}
 }
+
+func TestMatchesWithHeaders(t *testing.T) {
+	testcases := []struct {
+		method         string
+		stubUrl        string
+		stubHeaders    *http.Header
+		requestURL     string
+		requestHeaders http.Header
+		match          bool
+	}{
+		{
+			"get",
+			"http://example.com",
+			&http.Header{
+				"X-ApiKey": []string{"api-key"},
+			},
+			"http://example.com",
+			http.Header{
+				"X-ApiKey": []string{"api-key"},
+			},
+			true,
+		},
+		{
+			"get",
+			"http://example.com",
+			&http.Header{
+				"X-ApiKey": []string{"api-key"},
+			},
+			"http://example.com",
+			http.Header{
+				"X-ApiKey": []string{"another-api-key"},
+			},
+			false,
+		},
+		{
+			"get",
+			"http://example.com",
+			&http.Header{
+				"X-ApiKey": []string{"api-key"},
+				"Accept":   []string{"application/json"},
+			},
+			"http://example.com",
+			http.Header{
+				"X-ApiKey": []string{"api-key"},
+			},
+			false,
+		},
+	}
+
+	for _, testcase := range testcases {
+		stub, err := NewStubRequestWithHeaders(
+			testcase.method,
+			testcase.stubUrl,
+			testcase.stubHeaders,
+			NewStringResponder(200, "ok"),
+		)
+
+		if err != nil {
+			t.Fatalf("Unexpected error, got %#v", err)
+		}
+
+		req, err := http.NewRequest("GET", testcase.requestURL, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error, got %#v", err)
+		}
+
+		req.Header = testcase.requestHeaders
+
+		if stub.Matches(req) != testcase.match {
+			t.Errorf("Unexpected result expected '%#v', got '%#v' for %s", testcase.match, stub.Matches(req), testcase.stubUrl)
+		}
+	}
+}

--- a/stubbed_request_test.go
+++ b/stubbed_request_test.go
@@ -1,1 +1,67 @@
 package httpmock
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestMatches(t *testing.T) {
+	testcases := []struct {
+		method     string
+		url        string
+		requestURL string
+		match      bool
+	}{
+		{
+			"get",
+			"http://example.com",
+			"http://example.com",
+			true,
+		},
+		{
+			"get",
+			"ExAmPlE.com?foo=val&bar=val#t=boo",
+			"http://example.com?bar=val&foo=val#t=boo",
+			true,
+		},
+		{
+			"Get",
+			"http://example.com:80/?bar=val&foo=val#t=boo",
+			"http://example.com/?foo=val&bar=val#t=boo",
+			true,
+		},
+		{
+			"get",
+			"example.com?foo=val&bar=val&n=another#t=boo",
+			"http://example.com?bar=val&foo=val#t=boo",
+			false,
+		},
+		{
+			"GET",
+			"example.com/?foo=val&bar=val#t=bo",
+			"http://example.com/?foo=val&bar=val#t=boo",
+			false,
+		},
+	}
+
+	for _, testcase := range testcases {
+		stub, err := NewStubRequest(
+			testcase.method,
+			testcase.url,
+			NewStringResponder(200, "ok"),
+		)
+
+		if err != nil {
+			t.Fatalf("Unexpected error, got %#v", err)
+		}
+
+		req, err := http.NewRequest("GET", testcase.requestURL, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error, got %#v", err)
+		}
+
+		if stub.Matches(req) != testcase.match {
+			t.Errorf("Unexpected result expected '%#v', got '%#v' for %s", testcase.match, stub.Matches(req), testcase.url)
+		}
+	}
+}

--- a/stubbed_request_test.go
+++ b/stubbed_request_test.go
@@ -1,47 +1,60 @@
 package httpmock
 
 import (
-	//"bytes"
-	//"io"
+	"bytes"
+	"io"
 	"net/http"
 	"testing"
 )
 
 func TestMatches(t *testing.T) {
 	testcases := []struct {
-		method      string
-		url         string
-		requestURL  string
-		expectedErr bool
+		method        string
+		requestMethod string
+		url           string
+		requestURL    string
+		expectedErr   bool
 	}{
 		{
 			"get",
+			"GET",
 			"http://example.com",
 			"http://example.com",
 			false,
 		},
 		{
 			"get",
+			"GET",
 			"ExAmPlE.com?foo=val&bar=val#t=boo",
 			"http://example.com?bar=val&foo=val#t=boo",
 			false,
 		},
 		{
 			"Get",
+			"GET",
 			"http://example.com:80/?bar=val&foo=val#t=boo",
 			"http://example.com/?foo=val&bar=val#t=boo",
 			false,
 		},
 		{
 			"get",
+			"GET",
 			"example.com?foo=val&bar=val&n=another#t=boo",
 			"http://example.com?bar=val&foo=val#t=boo",
 			true,
 		},
 		{
 			"GET",
+			"GET",
 			"example.com/?foo=val&bar=val#t=bo",
 			"http://example.com/?foo=val&bar=val#t=boo",
+			true,
+		},
+		{
+			"get",
+			"POST",
+			"http://example.com",
+			"http://example.com",
 			true,
 		},
 	}
@@ -53,7 +66,7 @@ func TestMatches(t *testing.T) {
 			NewStringResponder(200, "ok"),
 		)
 
-		req, err := http.NewRequest("GET", testcase.requestURL, nil)
+		req, err := http.NewRequest(testcase.requestMethod, testcase.requestURL, nil)
 		if err != nil {
 			t.Fatalf("Unexpected error, got %#v", err)
 		}
@@ -71,115 +84,123 @@ func TestMatches(t *testing.T) {
 	}
 }
 
-//func TestMatchesWithHeader(t *testing.T) {
-//	testcases := []struct {
-//		method         string
-//		stubURL        string
-//		stubHeaders    *http.Header
-//		requestURL     string
-//		requestHeaders http.Header
-//		match          bool
-//	}{
-//		{
-//			"get",
-//			"http://example.com",
-//			&http.Header{
-//				"X-ApiKey": []string{"api-key"},
-//			},
-//			"http://example.com",
-//			http.Header{
-//				"X-ApiKey": []string{"api-key"},
-//			},
-//			true,
-//		},
-//		{
-//			"get",
-//			"http://example.com",
-//			&http.Header{
-//				"X-ApiKey": []string{"api-key"},
-//			},
-//			"http://example.com",
-//			http.Header{
-//				"X-ApiKey": []string{"another-api-key"},
-//			},
-//			false,
-//		},
-//		{
-//			"get",
-//			"http://example.com",
-//			&http.Header{
-//				"X-ApiKey": []string{"api-key"},
-//				"Accept":   []string{"application/json"},
-//			},
-//			"http://example.com",
-//			http.Header{
-//				"X-ApiKey": []string{"api-key"},
-//			},
-//			false,
-//		},
-//	}
-//
-//	for _, testcase := range testcases {
-//		stub := NewStubRequest(
-//			testcase.method,
-//			testcase.stubURL,
-//			NewStringResponder(200, "ok"),
-//		).WithHeader(testcase.stubHeaders)
-//
-//		req, err := http.NewRequest("GET", testcase.requestURL, nil)
-//		if err != nil {
-//			t.Fatalf("Unexpected error, got %#v", err)
-//		}
-//
-//		req.Header = testcase.requestHeaders
-//
-//		if stub.Matches(req) != testcase.match {
-//			t.Errorf("Unexpected result expected '%#v', got '%#v' for %s", testcase.match, stub.Matches(req), testcase.stubURL)
-//		}
-//	}
-//}
-//
-//func TestRequestWithBody(t *testing.T) {
-//	testcases := []struct {
-//		method      string
-//		stubURL     string
-//		body        io.Reader
-//		requestURL  string
-//		requestBody io.Reader
-//		match       bool
-//	}{
-//		{
-//			"POST",
-//			"http://example.com",
-//			bytes.NewBufferString("foo=val"),
-//			"http://example.com",
-//			bytes.NewBufferString("foo=val"),
-//			true,
-//		},
-//		{
-//			"POST",
-//			"http://example.com",
-//			bytes.NewBufferString("foo=val"),
-//			"http://example.com",
-//			bytes.NewBufferString("bar=val"),
-//			false,
-//		},
-//	}
-//
-//	for _, testcase := range testcases {
-//		stub := NewStubRequest(
-//			testcase.method,
-//			testcase.stubURL,
-//			NewStringResponder(200, "ok"),
-//		).WithBody(testcase.body)
-//
-//		req, err := http.NewRequest(testcase.method, testcase.requestURL, testcase.requestBody)
-//		if err != nil {
-//			t.Fatalf("Unexpected error, got %#v", err)
-//		}
-//
-//		if stub.Matches(req) != testcase.match {
-//			t.Errorf("Unexpected result expected '%#v', got '%#v' for %s", testcase.match, stub.Matches(req), testcase.stubURL)
-//		}
-//	}
-//}
+func TestMatchesWithHeader(t *testing.T) {
+	testcases := []struct {
+		method         string
+		stubURL        string
+		stubHeaders    *http.Header
+		requestURL     string
+		requestHeaders http.Header
+		expectedErr    bool
+	}{
+		{
+			"get",
+			"http://example.com",
+			&http.Header{
+				"X-ApiKey": []string{"api-key"},
+			},
+			"http://example.com",
+			http.Header{
+				http.CanonicalHeaderKey("X-ApiKey"): []string{"api-key"},
+			},
+			false,
+		},
+		{
+			"get",
+			"http://example.com",
+			&http.Header{
+				"X-ApiKey": []string{"api-key"},
+			},
+			"http://example.com",
+			http.Header{
+				http.CanonicalHeaderKey("X-ApiKey"): []string{"another-api-key"},
+			},
+			true,
+		},
+		{
+			"get",
+			"http://example.com",
+			&http.Header{
+				"X-ApiKey": []string{"api-key"},
+				"Accept":   []string{"application/json"},
+			},
+			"http://example.com",
+			http.Header{
+				http.CanonicalHeaderKey("X-ApiKey"): []string{"api-key"},
+			},
+			true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		stub := NewStubRequest(
+			testcase.method,
+			testcase.stubURL,
+			NewStringResponder(200, "ok"),
+		).WithHeader(testcase.stubHeaders)
+
+		req, err := http.NewRequest("GET", testcase.requestURL, nil)
+		if err != nil {
+			t.Fatalf("Unexpected error, got %#v", err)
+		}
+
+		req.Header = testcase.requestHeaders
+
+		err = stub.Matches(req)
+
+		if testcase.expectedErr && err == nil {
+			t.Errorf("Expected error, got none for %s", testcase.stubURL)
+		} else if !testcase.expectedErr && err != nil {
+			t.Errorf("Unexpected error, got '%#v' for %s", err, testcase.stubURL)
+		}
+	}
+}
+
+func TestRequestWithBody(t *testing.T) {
+	testcases := []struct {
+		method      string
+		stubURL     string
+		body        io.Reader
+		requestURL  string
+		requestBody io.Reader
+		expectedErr bool
+	}{
+		{
+			"POST",
+			"http://example.com",
+			bytes.NewBufferString("foo=val"),
+			"http://example.com",
+			bytes.NewBufferString("foo=val"),
+			false,
+		},
+		{
+			"POST",
+			"http://example.com",
+			bytes.NewBufferString("foo=val"),
+			"http://example.com",
+			bytes.NewBufferString("bar=val"),
+			true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		stub := NewStubRequest(
+			testcase.method,
+			testcase.stubURL,
+			NewStringResponder(200, "ok"),
+		).WithBody(testcase.body)
+
+		req, err := http.NewRequest(testcase.method, testcase.requestURL, testcase.requestBody)
+		if err != nil {
+			t.Fatalf("Unexpected error, got %#v", err)
+		}
+
+		err = stub.Matches(req)
+
+		if testcase.expectedErr && err == nil {
+			t.Errorf("Expected error, got none for %s", testcase.stubURL)
+		} else if !testcase.expectedErr && err != nil {
+			t.Errorf("Unexpected error, got '%#v' for %s", err, testcase.stubURL)
+		}
+	}
+}

--- a/transport.go
+++ b/transport.go
@@ -2,8 +2,8 @@ package httpmock
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
-	"strings"
 )
 
 // Responders are callbacks that receive and http request and return a mocked response.
@@ -39,7 +39,7 @@ func ConnectionFailure(*http.Request) (*http.Response, error) {
 // NewMockTransport creates a new *MockTransport with no stubbed requests.
 func NewMockTransport() *MockTransport {
 	return &MockTransport{
-		make([]*StubRequest),
+		make([]*StubRequest, 0),
 		nil,
 	}
 }
@@ -48,7 +48,7 @@ func NewMockTransport() *MockTransport {
 // an http.Client.  This implementation doesn't actually make the call, instead deferring to
 // the registered list of stubbed requests.
 type MockTransport struct {
-	stubs       []StubRequest
+	stubs       []*StubRequest
 	noResponder Responder
 }
 
@@ -106,7 +106,7 @@ func (m *MockTransport) RegisterNoResponder(responder Responder) {
 // Reset removes all registered responders (including the no responder) from
 // the MockTransport
 func (m *MockTransport) Reset() {
-	m.stubs = make([]*StubRequest)
+	m.stubs = make([]*StubRequest, 0)
 	m.noResponder = nil
 }
 

--- a/transport_test.go
+++ b/transport_test.go
@@ -138,33 +138,6 @@ func TestMockTransportNoResponder(t *testing.T) {
 	}
 }
 
-func TestMockTransportQuerystringFallback(t *testing.T) {
-	Activate()
-	defer DeactivateAndReset()
-
-	// register the testUrl responder
-	RegisterStubRequest(&StubRequest{
-		Method:    "GET",
-		URL:       testUrl,
-		Responder: NewStringResponder(200, "hello world"),
-	})
-
-	// make a request for the testUrl with a querystring
-	resp, err := http.Get(testUrl + "?hello=world")
-	if err != nil {
-		t.Fatal("expected request to succeed")
-	}
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if string(data) != "hello world" {
-		t.Fatal("expected body to be 'hello world'")
-	}
-}
-
 func TestMockTransportWithQuerystring(t *testing.T) {
 	Activate()
 	defer DeactivateAndReset()

--- a/transport_test.go
+++ b/transport_test.go
@@ -189,6 +189,11 @@ func TestMockTransportWithQuerystring(t *testing.T) {
 		t.Fatal("expected to receive a connection error due to lack of responders")
 	}
 
+	// should error if more parameters passed
+	if _, err := http.Get(testUrl + "?first=val&second=val&third=val"); err == nil {
+		t.Fatal("expected to receive a connection error due to lack of responders")
+	}
+
 	// should not error if both parameters are sent
 	_, err := http.Get(testUrl + "?first=val&second=val")
 	if err != nil {

--- a/transport_test.go
+++ b/transport_test.go
@@ -86,7 +86,7 @@ func TestMockTransportCaseInsensitive(t *testing.T) {
 func TestMockTransportReset(t *testing.T) {
 	DeactivateAndReset()
 
-	if len(DefaultTransport.requests) > 0 {
+	if len(DefaultTransport.stubs) > 0 {
 		t.Fatal("expected no responders at this point")
 	}
 
@@ -96,13 +96,13 @@ func TestMockTransportReset(t *testing.T) {
 		Responder: nil,
 	})
 
-	if len(DefaultTransport.requests) != 1 {
+	if len(DefaultTransport.stubs) != 1 {
 		t.Fatal("expected one stubbed request")
 	}
 
 	Reset()
 
-	if len(DefaultTransport.requests) > 0 {
+	if len(DefaultTransport.stubs) > 0 {
 		t.Fatal("expected no stubbed requests as they were just reset")
 	}
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -117,6 +117,38 @@ func TestMockTransportQuerystringFallback(t *testing.T) {
 	}
 }
 
+func TestMockTransportWithQuerystring(t *testing.T) {
+	Activate()
+	defer DeactivateAndReset()
+
+	// register a responder with query parameters
+	RegisterResponder("GET", testUrl+"?first=val&second=val", NewStringResponder(200, "hello world"))
+
+	// should error if no parameters passed
+	if _, err := http.Get(testUrl); err == nil {
+		t.Fatal("expected to receive a connection error due to lack of responders")
+	}
+
+	// should error if if only one parameter passed
+	if _, err := http.Get(testUrl + "?first=val"); err == nil {
+		t.Fatal("expected to receive a connection error due to lack of responders")
+	}
+	if _, err := http.Get(testUrl + "?second=val"); err == nil {
+		t.Fatal("expected to receive a connection error due to lack of responders")
+	}
+
+	// should not error if both parameters are sent
+	_, err := http.Get(testUrl + "?first=val&second=val")
+	if err != nil {
+		t.Fatal("expected request to succeed")
+	}
+
+	_, err = http.Get(testUrl + "?second=val&first=val")
+	if err != nil {
+		t.Fatal("expected request to succeed")
+	}
+}
+
 type dummyTripper struct{}
 
 func (d *dummyTripper) RoundTrip(*http.Request) (*http.Response, error) {

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,20 @@
+package httpmock
+
+import (
+	"github.com/goware/urlx"
+)
+
+// normalizeURL is a helper function that returns a normalized url
+func normalizeURL(url string) (string, error) {
+	u, err := urlx.Parse(url)
+	if err != nil {
+		return "", err
+	}
+
+	normalized, err := urlx.Normalize(u)
+	if err != nil {
+		return "", err
+	}
+
+	return normalized, nil
+}

--- a/utils.go
+++ b/utils.go
@@ -18,3 +18,15 @@ func normalizeURL(url string) (string, error) {
 
 	return normalized, nil
 }
+
+// contains is a simple function that checks for the presence of a string value
+// within a slice of strings
+func contains(values []string, value string) bool {
+	for _, v := range values {
+		if v == value {
+			return true
+		}
+	}
+
+	return false
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -6,25 +6,55 @@ import (
 
 func TestNormalizeURL(t *testing.T) {
 	testcases := []struct {
-		input       string
+		inputs      []string
 		expected    string
 		expectedErr bool
 	}{
 		{
-			"http://example.com",
-			"http://example.com",
+			[]string{
+				"www.example.com",
+				"www.example.com:80",
+				"http://www.example.com",
+				"HTTP://WWW.eXamPle.Com:80",
+			},
+			"http://www.example.com",
 			false,
+		},
+		{
+			[]string{
+				"http://www.example.com/a/b/index.html?foo=val&bar=val#t=20",
+				"www.example.com:80/a/b///../x/../../index.html?foo=val&bar=val#t=20",
+			},
+			"http://www.example.com/a/b/index.html?bar=val&foo=val#t=20",
+			false,
+		},
+		{
+			[]string{
+				"<funnytag>",
+				"javascript:evilFunc()",
+				"anotherscheme:garbage",
+			},
+			"",
+			true,
 		},
 	}
 
 	for _, testcase := range testcases {
-		got, err := normalizeURL(testcase.input)
-		if err != nil && !testcase.expectedErr {
-			t.Errorf("Unexpected error, got %#v", err)
-		}
+		for _, input := range testcase.inputs {
+			got, err := normalizeURL(input)
+			if testcase.expectedErr {
+				if err == nil {
+					t.Errorf("Expected error for '%s', got none", input)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error, got %#v", err)
+				}
 
-		if got != testcase.expected {
-			t.Errorf("Unexepcted output, expected: %s, got %s", testcase.expected, got)
+				if got != testcase.expected {
+					t.Errorf("Unexepcted output, expected: %s, got %s", testcase.expected, got)
+				}
+			}
 		}
 	}
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,30 @@
+package httpmock
+
+import (
+	"testing"
+)
+
+func TestNormalizeURL(t *testing.T) {
+	testcases := []struct {
+		input       string
+		expected    string
+		expectedErr bool
+	}{
+		{
+			"http://example.com",
+			"http://example.com",
+			false,
+		},
+	}
+
+	for _, testcase := range testcases {
+		got, err := normalizeURL(testcase.input)
+		if err != nil && !testcase.expectedErr {
+			t.Errorf("Unexpected error, got %#v", err)
+		}
+
+		if got != testcase.expected {
+			t.Errorf("Unexepcted output, expected: %s, got %s", testcase.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
These changes allow us to declare stubs that will only match if requests are made with the correct parameters or headers as well as the request body.

In addition it gives a method by which we can verify that all declared stubs have actually been called.
